### PR TITLE
:sparkles: Add utility to persist activation traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ To assess the reusability of our code, far beyond just reproducibility,
 we refer to the next section where we show dedicated, general-purpose artifacts
 extracted from this reproduction package.
 
+**AT Generation** Due to a 3rd party request after paper publication, 
+we have added a new command `python reproduction.py --phase at_collection` to the CLI.
+It allows to persist the activation traces for our models (all layers, including input and output)
+to the file system. As above, the interactive CLI allows to narrow down the selection of datasets/models.
+Attention: The ATs for all models and all dataset will add up to multiple terrabytes of data.
+Running the AT generation command has no impact on the other experiments. 
+Still, if anyone wants to reproduce using the exact version of the code we used, they should stick 
+to the docker image and code for version `v0.1.0`.
+
 ## :rocket:  :rocket:  :rocket: Extracted General-Purpose Artifacts :rocket: :rocket: :rocket:
 Running the above described reproduction package allows to verify the results 
 shown in the paper.

--- a/reproduction.py
+++ b/reproduction.py
@@ -16,6 +16,7 @@ class ReproductionType(str, Enum):
     TEST_PRIO = "test_prio"
     ACTIVE_LEARNING = "active_learning"
     EVAL = "evaluation"
+    ACTIVATION_COLLECTION = "at_collection"
 
 
 class CaseStudyType(str, Enum):
@@ -112,6 +113,14 @@ def _cs_runner_for_case_study(case_study: CaseStudyType):
 
 def _setup_non_eval(r_type: ReproductionType):
     # Make sure user really wants to do this
+    if r_type == ReproductionType.ACTIVATION_COLLECTION:
+        typer.echo(
+            f"Note that activation collection has only been added after paper"
+            f"publication (due to a 3rd party request). "
+            f"This step has thus not been used to collect our results, "
+            f"but may help you when doing your own activation-based work."
+        )
+
     confirmed = typer.confirm(
         f"Are you sure you want to run the {r_type} steps of the experiments? "
         f"These typically take a long time to run, "
@@ -123,7 +132,7 @@ def _setup_non_eval(r_type: ReproductionType):
         raise typer.Abort()
 
     case_study: CaseStudyType = typer.prompt(
-        "Please enter the case study you want to reproduce",
+        "Please enter the case study you want to run",
         type=click.Choice([c.value for c in CaseStudyType], case_sensitive=False),
     )
     run: Union[int, List[int]] = typer.prompt(
@@ -161,6 +170,10 @@ def _setup_non_eval(r_type: ReproductionType):
     elif r_type == ReproductionType.ACTIVE_LEARNING:
         cs_runner.run_active_learning_eval(
             run, num_processes=1, context=SingleUseContext
+        )
+    elif r_type == ReproductionType.ACTIVATION_COLLECTION:
+        cs_runner.collect_activations(
+            model_ids=run, num_processes=1, context=SingleUseContext
         )
     else:
         typer.echo(f"Unknown reproduction type: {r_type}", err=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pingouin==0.5.0
 
 polyleven==0.7 # Fast levenshtein distance implementation
 
-typer==0.3.2
+typer==0.4.1

--- a/src/dnn_test_prio/activation_persistor.py
+++ b/src/dnn_test_prio/activation_persistor.py
@@ -1,0 +1,72 @@
+"""Utility (not used for paper) to extract activations from our models"""
+import os.path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import tensorflow as tf
+
+from src.dnn_test_prio.handler_model import BaseModel
+
+BADGE_SIZE = 100
+
+
+def _persist_badge(
+    case_study: str,
+    model_id: int,
+    dataset: str,
+    badge_id: int,
+    activations: List[np.ndarray],
+    labels: np.ndarray,
+):
+    path = os.path.join(
+        "/assets", "activations", case_study, f"model_{model_id}", dataset
+    )
+
+    for layer_i, layer_at in enumerate(activations):
+        folder = os.path.join(path, f"layer_{layer_i}")
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        np.save(os.path.join(folder, f"badge_{badge_id}.npy"), layer_at)
+
+    labels_folder = os.path.join(path, "labels")
+    if not os.path.exists(labels_folder):
+        os.makedirs(labels_folder)
+    np.save(os.path.join(labels_folder, f"badge_{badge_id}.npy"), labels)
+
+
+def persist(
+    model: tf.keras.Sequential,
+    case_study: str,
+    model_id: int,
+    train_set: Tuple[np.ndarray, np.ndarray],
+    test_nominal: Tuple[np.ndarray, np.ndarray],
+    test_corrupted: Tuple[np.ndarray, np.ndarray],
+) -> None:
+    """Persist the activations of the model."""
+    # Activations of all layers
+    layer_ids = list(range(len(model.layers)))
+    # Note: `include_last_layer = False` as already included in list above.
+    transparent_model = BaseModel(
+        model=model, activation_layers=layer_ids, include_last_layer=False
+    )
+
+    for ds, (x, y) in {
+        "train": train_set,
+        "test_nominal": test_nominal,
+        "test_nominal_and_corrupted": test_corrupted,
+    }.items():
+        badge_stream = tf.data.Dataset.from_tensor_slices((x, y)).batch(BADGE_SIZE)
+        print(
+            f"Started collecting activations "
+            f"for {badge_stream.cardinality()} {case_study}-{ds} badges."
+        )
+        for badge_id, (badge_x, badge_y) in enumerate(badge_stream.as_numpy_iterator()):
+            activations = transparent_model.get_activations(badge_x)
+            _persist_badge(
+                case_study,
+                model_id,
+                ds,
+                badge_id=badge_id,
+                activations=activations,
+                labels=badge_y,
+            )

--- a/src/dnn_test_prio/case_study.py
+++ b/src/dnn_test_prio/case_study.py
@@ -63,6 +63,17 @@ class CaseStudy(abc.ABC):
         `eval_active_learning.evaluate(...)`."""
         pass
 
+    @staticmethod
+    @abc.abstractmethod
+    def _activation_persistor() -> Callable[[int, tf.keras.Model], None]:
+        """A picklable function to save activation traces to file systems.
+
+        The returned function would typically be a wrapper around
+        `activation_persistor.persist(...)`.
+
+        **This was not used for our experiments.**"""
+        pass
+
     def train(
         self,
         model_ids: List[int],
@@ -109,6 +120,24 @@ class CaseStudy(abc.ABC):
         or the reproduction CLI."""
         self.ens.consume(
             self._active_learning_evaluator(),
+            models=model_ids,
+            num_processes=num_processes,
+            context=context,
+        )
+
+    def collect_activations(
+        self,
+        model_ids: List[int],
+        num_processes: int,
+        context: Callable[[int], EnsembleContextManager] = None,
+    ):
+        """Utility to store all activations on the file system.
+
+        This was not actually used as part of our paper,
+        but requested by a 3rd party to allow to build on our model
+        activations without using our code directly."""
+        self.ens.consume(
+            self._activation_persistor(),
             models=model_ids,
             num_processes=num_processes,
             context=context,

--- a/src/dnn_test_prio/case_study_cifar10.py
+++ b/src/dnn_test_prio/case_study_cifar10.py
@@ -8,7 +8,11 @@ import numpy as np
 import tensorflow as tf
 import uncertainty_wizard
 
-from src.dnn_test_prio import eval_active_learning, eval_prioritization
+from src.dnn_test_prio import (
+    activation_persistor,
+    eval_active_learning,
+    eval_prioritization,
+)
 from src.dnn_test_prio.case_study import OUTPUT_FOLDER, CaseStudy
 
 CASE_STUDY = "cifar10"
@@ -119,6 +123,19 @@ def _cifar10_prio_evaluator(model_id: int, model: tf.keras.Model) -> None:
     )
 
 
+def _cifar_activation_persistor(model_id: int, model: tf.keras.Model) -> None:
+    logging.basicConfig(level=logging.INFO)
+    train, nom, ood = _load_datasets()
+    return activation_persistor.persist(
+        model=model,
+        case_study="cifar10",
+        model_id=model_id,
+        train_set=train,
+        test_nominal=nom,
+        test_corrupted=ood,
+    )
+
+
 def _load_datasets():
     # prepare data
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar10.load_data()
@@ -203,6 +220,10 @@ class Cifar10CaseStudy(CaseStudy):
     @staticmethod
     def _active_learning_evaluator() -> Callable[[int, tf.keras.Model], None]:
         return _mnist_active_learning_evaluator
+
+    @staticmethod
+    def _activation_persistor() -> Callable[[int, tf.keras.Model], None]:
+        return _cifar_activation_persistor
 
 
 if __name__ == "__main__":

--- a/src/dnn_test_prio/case_study_fashion_mnist.py
+++ b/src/dnn_test_prio/case_study_fashion_mnist.py
@@ -8,7 +8,11 @@ import numpy as np
 import tensorflow as tf
 import uncertainty_wizard
 
-from src.dnn_test_prio import eval_active_learning, eval_prioritization
+from src.dnn_test_prio import (
+    activation_persistor,
+    eval_active_learning,
+    eval_prioritization,
+)
 from src.dnn_test_prio.case_study import CaseStudy
 
 CASE_STUDY = "fmnist"
@@ -114,6 +118,19 @@ def _fashion_mnist_prio_evaluator(model_id: int, model: tf.keras.Model) -> None:
     )
 
 
+def _fmnist_activation_persistor(model_id: int, model: tf.keras.Model) -> None:
+    logging.basicConfig(level=logging.INFO)
+    train, nom, ood = _load_datasets()
+    return activation_persistor.persist(
+        model=model,
+        case_study="fmnist",
+        model_id=model_id,
+        train_set=train,
+        test_nominal=nom,
+        test_corrupted=ood,
+    )
+
+
 def _load_datasets():
     # prepare data
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.fashion_mnist.load_data()
@@ -158,6 +175,10 @@ class FashionMnistCaseStudy(CaseStudy):
     @staticmethod
     def _active_learning_evaluator() -> Callable[[int, tf.keras.Model], None]:
         return _fashion_mnist_active_learning_evaluator
+
+    @staticmethod
+    def _activation_persistor() -> Callable[[int, tf.keras.Model], None]:
+        return _fmnist_activation_persistor
 
 
 if __name__ == "__main__":

--- a/src/dnn_test_prio/case_study_imdb.py
+++ b/src/dnn_test_prio/case_study_imdb.py
@@ -11,6 +11,7 @@ import uncertainty_wizard
 from datasets import load_dataset
 from src.core.text_corruptor import TextCorruptor
 from src.dnn_test_prio import (
+    activation_persistor,
     eval_active_learning,
     eval_prioritization,
     memory_leak_avoider,
@@ -254,6 +255,19 @@ def _imdb_prio_evaluator(model_id: int, model: tf.keras.Model) -> None:
     )
 
 
+def _imdb_activation_persistor(model_id: int, model: tf.keras.Model) -> None:
+    logging.basicConfig(level=logging.INFO)
+    train, nom, ood = _load_datasets()
+    return activation_persistor.persist(
+        model=model,
+        case_study="imdb",
+        model_id=model_id,
+        train_set=train,
+        test_nominal=nom,
+        test_corrupted=ood,
+    )
+
+
 def _load_datasets():
     x_train = np.load(os.path.join(DS_CACHE_FOLDER, "x_train.npy"))
     y_train = np.load(os.path.join(DS_CACHE_FOLDER, "y_train.npy"))
@@ -343,6 +357,10 @@ class ImdbCaseStudy(CaseStudy):
     @staticmethod
     def _active_learning_evaluator() -> Callable[[int, tf.keras.Model], None]:
         return _imdb_active_learning_evaluator
+
+    @staticmethod
+    def _activation_persistor() -> Callable[[int, tf.keras.Model], None]:
+        return _imdb_activation_persistor
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Due to a 3rd party request after paper publication, we have added a new reproduction phase `python reproduction.py --phase at_collection` to the CLI. It allows persisting the activation traces for our models (all layers, including input and output) to the file system. The interactive CLI allows to narrow down the selection of datasets/models. 

I will keep this PR on hold until artifact evaluation has been completed, to avoid any confusion or interferences.